### PR TITLE
Basic認証とCSRFトークンの無効化

### DIFF
--- a/src/main/kotlin/com/ppap/torimocore/application/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/ppap/torimocore/application/config/SecurityConfiguration.kt
@@ -1,0 +1,18 @@
+package com.ppap.torimocore.application.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+
+/**
+ * 全てのパスからBasic認証を無効化するConfigurationです。
+ */
+@Configuration
+@EnableWebSecurity
+class SecurityConfiguration : WebSecurityConfigurerAdapter() {
+    @Throws(Exception::class)
+    override fun configure(http: HttpSecurity) {
+        http.authorizeRequests().antMatchers("/").permitAll()
+    }
+}

--- a/src/main/kotlin/com/ppap/torimocore/application/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/ppap/torimocore/application/config/SecurityConfiguration.kt
@@ -6,13 +6,17 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 
 /**
- * 全てのパスからBasic認証を無効化するConfigurationです。
+ * Spring SecurityのConfigurationです。
  */
 @Configuration
 @EnableWebSecurity
 class SecurityConfiguration : WebSecurityConfigurerAdapter() {
     @Throws(Exception::class)
     override fun configure(http: HttpSecurity) {
-        http.authorizeRequests().antMatchers("/").permitAll()
+        http.
+                // Basic認証の無効化
+                authorizeRequests().antMatchers("/").permitAll().and().
+                // CSRFトークンの無効化 TODO: 多分いずれちゃんとやらないといけないやーつ
+                csrf().disable()
     }
 }

--- a/src/main/kotlin/com/ppap/torimocore/application/filter/FilterBean.kt
+++ b/src/main/kotlin/com/ppap/torimocore/application/filter/FilterBean.kt
@@ -13,7 +13,7 @@ class FilterConfig {
     fun authFilter(useCase: AuthUseCase): FilterRegistrationBean<*> {
         // 認証をしたいパスを設定する
         val authUrls = listOf(
-                "test"
+                "/test"
         )
         val filter = AuthFilter(useCase)
         return FilterRegistrationBean(filter).apply {


### PR DESCRIPTION
## 変更点
Spring Securityでは確かデフォルトでBasic認証がかかってしまうためそれを無効化するConfigurationを追加しました。

POSTメソッドでCSRFトークンを求められるので検証中邪魔なので一旦無効化しました。
多分、いずれはちゃんとやらなきゃいけないやつな気がします。

また`authFilter`のパスのリストの先頭に`/`を入れないとパスの読み込みが出来ずにこけていたので追加しました。

FYI

https://intellectual-curiosity.tokyo/2019/04/14/spring-boot-2-x-%E3%81%A7basic%E8%AA%8D%E8%A8%BC%E3%82%92%E7%84%A1%E5%8A%B9%E3%81%AB%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95/