### PR TITLE
エラーハンドリングの修正

### DIFF
--- a/src/main/kotlin/com/ppap/torimocore/application/handler/ErrorHandler.kt
+++ b/src/main/kotlin/com/ppap/torimocore/application/handler/ErrorHandler.kt
@@ -1,14 +1,15 @@
 package com.ppap.torimocore.application.handler
 
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.security.authentication.BadCredentialsException
-import java.util.HashMap
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 
+typealias Response = Map<String, Any?>
 
 @ControllerAdvice
 class ExceptionHandler {
@@ -16,22 +17,17 @@ class ExceptionHandler {
     @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
     @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
     @ResponseBody
-    fun handleError(): Map<String, Any> {
-        val errorMap = HashMap<String, Any>()
-        return mapOf(
-                "statusCode" to HttpStatus.METHOD_NOT_ALLOWED.value().toString(),
-                "message" to "許可されていないメソッドです"
-        )
-    }
+    fun handleError(): ResponseEntity<Response> = ResponseEntity(mapOf(
+            "statusCode" to HttpStatus.METHOD_NOT_ALLOWED.value().toString(),
+            "message" to "許可されていないメソッドです"
+    ), HttpStatus.METHOD_NOT_ALLOWED)
 
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(BadCredentialsException::class)
     @ResponseBody
-    fun tokenError(e: BadCredentialsException): Map<String, String?> {
-        return mapOf(
-                "statusCode" to HttpStatus.UNAUTHORIZED.value().toString(),
-                "message" to e.message
-        )
-    }
+    fun tokenError(e: BadCredentialsException): ResponseEntity<Response> = ResponseEntity(mapOf(
+            "statusCode" to HttpStatus.UNAUTHORIZED.value().toString(),
+            "message" to e.message
+    ), HttpStatus.UNAUTHORIZED)
 
 }

--- a/src/main/kotlin/com/ppap/torimocore/application/handler/ErrorHandler.kt
+++ b/src/main/kotlin/com/ppap/torimocore/application/handler/ErrorHandler.kt
@@ -1,5 +1,6 @@
 package com.ppap.torimocore.application.handler
 
+import com.ppap.torimocore.constants.*
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.authentication.BadCredentialsException
@@ -9,25 +10,23 @@ import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 
-typealias Body = Map<String, Any?>
-
 @ControllerAdvice
 class ExceptionHandler {
 
     @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
     @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
     @ResponseBody
-    fun handleError(): ResponseEntity<Body> = ResponseEntity(mapOf(
-            "statusCode" to HttpStatus.METHOD_NOT_ALLOWED.value().toString(),
-            "message" to "許可されていないメソッドです"
+    fun handleError(): Response = ResponseEntity(mapOf(
+            STATUS_CODE to HttpStatus.METHOD_NOT_ALLOWED.value().toString(),
+            MESSAGE to "許可されていないメソッドです"
     ), HttpStatus.METHOD_NOT_ALLOWED)
 
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(BadCredentialsException::class)
     @ResponseBody
-    fun tokenError(e: BadCredentialsException): ResponseEntity<Body> = ResponseEntity(mapOf(
-            "statusCode" to HttpStatus.UNAUTHORIZED.value().toString(),
-            "message" to e.message
+    fun tokenError(e: BadCredentialsException): Response = ResponseEntity(mapOf(
+            STATUS_CODE to HttpStatus.UNAUTHORIZED.value().toString(),
+            MESSAGE to e.message
     ), HttpStatus.UNAUTHORIZED)
 
 }

--- a/src/main/kotlin/com/ppap/torimocore/application/handler/ErrorHandler.kt
+++ b/src/main/kotlin/com/ppap/torimocore/application/handler/ErrorHandler.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 
-typealias Response = Map<String, Any?>
+typealias Body = Map<String, Any?>
 
 @ControllerAdvice
 class ExceptionHandler {
@@ -17,7 +17,7 @@ class ExceptionHandler {
     @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
     @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
     @ResponseBody
-    fun handleError(): ResponseEntity<Response> = ResponseEntity(mapOf(
+    fun handleError(): ResponseEntity<Body> = ResponseEntity(mapOf(
             "statusCode" to HttpStatus.METHOD_NOT_ALLOWED.value().toString(),
             "message" to "許可されていないメソッドです"
     ), HttpStatus.METHOD_NOT_ALLOWED)
@@ -25,7 +25,7 @@ class ExceptionHandler {
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(BadCredentialsException::class)
     @ResponseBody
-    fun tokenError(e: BadCredentialsException): ResponseEntity<Response> = ResponseEntity(mapOf(
+    fun tokenError(e: BadCredentialsException): ResponseEntity<Body> = ResponseEntity(mapOf(
             "statusCode" to HttpStatus.UNAUTHORIZED.value().toString(),
             "message" to e.message
     ), HttpStatus.UNAUTHORIZED)

--- a/src/main/kotlin/com/ppap/torimocore/constants/HttpResponse.kt
+++ b/src/main/kotlin/com/ppap/torimocore/constants/HttpResponse.kt
@@ -1,0 +1,9 @@
+package com.ppap.torimocore.constants
+
+import org.springframework.http.ResponseEntity
+
+val STATUS_CODE = "statusCode"
+val MESSAGE = "message"
+
+typealias Body = Map<String, Any?>
+typealias Response = ResponseEntity<Body>

--- a/src/main/kotlin/com/ppap/torimocore/presentation/controller/ArticleLikeController.kt
+++ b/src/main/kotlin/com/ppap/torimocore/presentation/controller/ArticleLikeController.kt
@@ -1,5 +1,6 @@
 package com.ppap.torimocore.presentation.controller
 
+import com.ppap.torimocore.constants.Response
 import com.ppap.torimocore.presentation.dto.ArticleLikeFormDto
 import com.ppap.torimocore.usecase.ArticleLikeUseCase
 import org.springframework.http.HttpStatus
@@ -20,14 +21,14 @@ import org.springframework.web.client.HttpClientErrorException
 class ArticleLikeController(private val useCase: ArticleLikeUseCase) : ControllerBase() {
 
     @PostMapping("like")
-    fun like(@RequestBody @Validated form: ArticleLikeFormDto, bindingResult: BindingResult): Map<String, String?> {
+    fun like(@RequestBody @Validated form: ArticleLikeFormDto, bindingResult: BindingResult): Response {
         if (bindingResult.hasErrors()) throw HttpClientErrorException(HttpStatus.BAD_REQUEST, bindingResult.allErrors.toString())
         useCase.like(form.convert())
         return createResponse(HttpStatus.OK)
     }
 
     @PostMapping("unlike")
-    fun unlike(@RequestBody form: ArticleLikeFormDto, bindingResult: BindingResult): Map<String, String?> {
+    fun unlike(@RequestBody form: ArticleLikeFormDto, bindingResult: BindingResult): Response {
         if (bindingResult.hasErrors()) throw HttpClientErrorException(HttpStatus.BAD_REQUEST, bindingResult.allErrors.toString())
         useCase.unlike(form.convert())
         return createResponse(HttpStatus.OK)

--- a/src/main/kotlin/com/ppap/torimocore/presentation/controller/ControllerBase.kt
+++ b/src/main/kotlin/com/ppap/torimocore/presentation/controller/ControllerBase.kt
@@ -1,5 +1,6 @@
 package com.ppap.torimocore.presentation.controller
 
+import com.ppap.torimocore.constants.*
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CrossOrigin
@@ -9,20 +10,15 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.client.HttpClientErrorException
 import java.lang.RuntimeException
 
-typealias Body = Map<String, Any?>
-
 @CrossOrigin
 @RestController
 class ControllerBase {
 
-    private val STATUS_CODE = "statusCode"
-    private val MESSAGE = "message"
-
-    fun createResponse(status: HttpStatus): ResponseEntity<Body> =
+    fun createResponse(status: HttpStatus): Response =
             ResponseEntity(mapOf(STATUS_CODE to status.value(), MESSAGE to status.reasonPhrase), status)
 
     @ExceptionHandler(HttpClientErrorException::class)
-    fun httpClientError(e: HttpClientErrorException): ResponseEntity<Body> = when (e.statusCode) {
+    fun httpClientError(e: HttpClientErrorException): Response = when (e.statusCode) {
         // 随時必要なStatusを実装してください
         HttpStatus.BAD_REQUEST -> badRequest(e)
         HttpStatus.NOT_FOUND -> notFound(e)
@@ -30,12 +26,12 @@ class ControllerBase {
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    private fun badRequest(e: HttpClientErrorException): ResponseEntity<Body> = createResponse(e)
+    private fun badRequest(e: HttpClientErrorException): Response = createResponse(e)
 
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    private fun notFound(e: HttpClientErrorException): ResponseEntity<Body> = createResponse(e)
+    private fun notFound(e: HttpClientErrorException): Response = createResponse(e)
 
-    private fun createResponse(e: HttpClientErrorException): ResponseEntity<Body> =
+    private fun createResponse(e: HttpClientErrorException): Response =
             ResponseEntity(mapOf(STATUS_CODE to e.statusCode.value(), MESSAGE to e.message), e.statusCode)
 
 }

--- a/src/main/kotlin/com/ppap/torimocore/presentation/controller/ControllerBase.kt
+++ b/src/main/kotlin/com/ppap/torimocore/presentation/controller/ControllerBase.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.client.HttpClientErrorException
 import java.lang.RuntimeException
 
-typealias Response = Map<String, Any?>
+typealias Body = Map<String, Any?>
 
 @CrossOrigin
 @RestController
@@ -18,11 +18,11 @@ class ControllerBase {
     private val STATUS_CODE = "statusCode"
     private val MESSAGE = "message"
 
-    fun createResponse(status: HttpStatus): ResponseEntity<Response> =
+    fun createResponse(status: HttpStatus): ResponseEntity<Body> =
             ResponseEntity(mapOf(STATUS_CODE to status.value(), MESSAGE to status.reasonPhrase), status)
 
     @ExceptionHandler(HttpClientErrorException::class)
-    fun httpClientError(e: HttpClientErrorException): ResponseEntity<Response> = when (e.statusCode) {
+    fun httpClientError(e: HttpClientErrorException): ResponseEntity<Body> = when (e.statusCode) {
         // 随時必要なStatusを実装してください
         HttpStatus.BAD_REQUEST -> badRequest(e)
         HttpStatus.NOT_FOUND -> notFound(e)
@@ -30,12 +30,12 @@ class ControllerBase {
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    private fun badRequest(e: HttpClientErrorException): ResponseEntity<Response> = createResponse(e)
+    private fun badRequest(e: HttpClientErrorException): ResponseEntity<Body> = createResponse(e)
 
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    private fun notFound(e: HttpClientErrorException): ResponseEntity<Response> = createResponse(e)
+    private fun notFound(e: HttpClientErrorException): ResponseEntity<Body> = createResponse(e)
 
-    private fun createResponse(e: HttpClientErrorException): ResponseEntity<Response> =
+    private fun createResponse(e: HttpClientErrorException): ResponseEntity<Body> =
             ResponseEntity(mapOf(STATUS_CODE to e.statusCode.value(), MESSAGE to e.message), e.statusCode)
 
 }

--- a/src/main/kotlin/com/ppap/torimocore/presentation/controller/ControllerBase.kt
+++ b/src/main/kotlin/com/ppap/torimocore/presentation/controller/ControllerBase.kt
@@ -1,11 +1,15 @@
 package com.ppap.torimocore.presentation.controller
 
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.client.HttpClientErrorException
+import java.lang.RuntimeException
+
+typealias Response = Map<String, Any?>
 
 @CrossOrigin
 @RestController
@@ -14,38 +18,24 @@ class ControllerBase {
     private val STATUS_CODE = "statusCode"
     private val MESSAGE = "message"
 
-    fun createResponse(status: HttpStatus): Map<String, String?> {
-        return mapOf(
-                STATUS_CODE  to status.value().toString(),
-                MESSAGE  to status.reasonPhrase
-        )
-    }
+    fun createResponse(status: HttpStatus): ResponseEntity<Response> =
+            ResponseEntity(mapOf(STATUS_CODE to status.value(), MESSAGE to status.reasonPhrase), status)
 
     @ExceptionHandler(HttpClientErrorException::class)
-    fun httpClientError(e: HttpClientErrorException): Map<String, String?> {
-        return when (e.statusCode) {
-            // 随時必要なStatusを実装してください
-            HttpStatus.BAD_REQUEST -> badRequest(e)
-            HttpStatus.NOT_FOUND -> notFound(e)
-            else -> emptyMap() // TODO: 雑だから適切な処理の実装
-        }
+    fun httpClientError(e: HttpClientErrorException): ResponseEntity<Response> = when (e.statusCode) {
+        // 随時必要なStatusを実装してください
+        HttpStatus.BAD_REQUEST -> badRequest(e)
+        HttpStatus.NOT_FOUND -> notFound(e)
+        else -> throw RuntimeException("Not implemented handling status code")
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    private fun badRequest(e: HttpClientErrorException): Map<String, String?> {
-        return createResponse(e)
-    }
+    private fun badRequest(e: HttpClientErrorException): ResponseEntity<Response> = createResponse(e)
 
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    private fun notFound(e: HttpClientErrorException): Map<String, String?> {
-        return createResponse(e)
-    }
+    private fun notFound(e: HttpClientErrorException): ResponseEntity<Response> = createResponse(e)
 
-    private fun createResponse(e: HttpClientErrorException): Map<String, String?> {
-        return mapOf(
-                STATUS_CODE to e.statusCode.value().toString(),
-                MESSAGE to e.message
-        )
-    }
+    private fun createResponse(e: HttpClientErrorException): ResponseEntity<Response> =
+            ResponseEntity(mapOf(STATUS_CODE to e.statusCode.value(), MESSAGE to e.message), e.statusCode)
 
 }

--- a/src/main/kotlin/com/ppap/torimocore/presentation/controller/FollowUserController.kt
+++ b/src/main/kotlin/com/ppap/torimocore/presentation/controller/FollowUserController.kt
@@ -1,5 +1,6 @@
 package com.ppap.torimocore.presentation.controller
 
+import com.ppap.torimocore.constants.Response
 import com.ppap.torimocore.presentation.dto.FollowUserFormDto
 import com.ppap.torimocore.usecase.FollowUserUseCase
 import org.springframework.http.HttpStatus
@@ -17,14 +18,14 @@ import org.springframework.web.client.HttpClientErrorException
 class FollowUserController(private val usecase: FollowUserUseCase) : ControllerBase() {
 
     @PostMapping("follow")
-    fun follow(@RequestBody @Validated form: FollowUserFormDto, bindingResult: BindingResult): Map<String, String?> {
+    fun follow(@RequestBody @Validated form: FollowUserFormDto, bindingResult: BindingResult): Response {
         if (bindingResult.hasErrors()) throw HttpClientErrorException(HttpStatus.BAD_REQUEST, bindingResult.allErrors.toString())
         usecase.follow(form.convert())
         return createResponse(HttpStatus.OK)
     }
 
     @PostMapping("unfollow")
-    fun unfollow(@RequestBody @Validated form: FollowUserFormDto, bindingResult: BindingResult): Map<String, String?> {
+    fun unfollow(@RequestBody @Validated form: FollowUserFormDto, bindingResult: BindingResult): Response {
         if (bindingResult.hasErrors()) throw HttpClientErrorException(HttpStatus.BAD_REQUEST, bindingResult.allErrors.toString())
         usecase.unfollow(form.convert())
         return createResponse(HttpStatus.OK)


### PR DESCRIPTION
## 修正
エラーハンドリング時、bodyの内容関係なくhttpステータスが200になってしまっていたのでその修正。（Map<K,V>返してたらそらそうですよね....）
ResponseEntity<T>を返して、その際にhttpステータスをセットすることで正しいhttpステータスで返せるそうです！